### PR TITLE
fix expected and actual result comparison

### DIFF
--- a/config/generateMD.js
+++ b/config/generateMD.js
@@ -20,7 +20,7 @@ const assertionErrors = (_name, asserts) => {
         actualOutput = fn();
       }
 
-      if (actualOutput !== assert.output) {
+      if (JSON.stringify(actualOutput) !== JSON.stringify(assert.output)) {
         errors.push(
           `INPUT: ${assert.input || "None"} \n\tEXPECTED: ${
             assert.output


### PR DESCRIPTION
Once the expected and actual results are arrays, the comparison doesn't work.
This fixes: https://github.com/Swendude/35funcs/issues/5